### PR TITLE
add 'favorite_other' event type

### DIFF
--- a/lib/chatroid/adapter/twitter/event.rb
+++ b/lib/chatroid/adapter/twitter/event.rb
@@ -29,6 +29,8 @@ class Chatroid
             "reply"
           elsif tweet?
             "tweet"
+          elsif favorite?
+            "favorite_other"
           else
             "unknown"
           end
@@ -50,6 +52,10 @@ class Chatroid
 
         def tweet?
           @params["text"]
+        end
+
+        def favorite?
+          @params["event"] == "favorite"
         end
       end
     end

--- a/spec/chatroid/adapter/twitter/event_spec.rb
+++ b/spec/chatroid/adapter/twitter/event_spec.rb
@@ -14,6 +14,10 @@ describe Chatroid::Adapter::Twitter::Event do
       1
     end
 
+    let (:other_id) do
+      2
+    end
+
     context "when favorited" do
       let(:args) do
         { "event" => "favorite", "target" => { "id" => user_id } }
@@ -21,6 +25,16 @@ describe Chatroid::Adapter::Twitter::Event do
 
       it do
         should == "favorite"
+      end
+    end
+
+    context "when user favorited other's tweet" do
+      let(:args) do
+        { "event" => "favorite", "target" => { "id" => other_id } }
+      end
+
+      it do
+        should == "favorite_other"
       end
     end
 


### PR DESCRIPTION
Hello. I'm thank you for this fantastic gem.

When I make a twitter datastore application, I want to handle 'user favorites' event via Chatroid API. So, I made this pull request.

By this change, user can call `on_favorite_other` method in Chatroid instance.

``` ruby
Chatroid.new do
  on_favorite_other do |event|
    "some codes"
  end
end.run!
```

I'm worry about this event type name, 'favorite_other'. This is not cool, but `on_favorite` is booked as 'user is favorited' event. If you have good idea for this, please feel free to change.

And I'm beginner on making pull request, maybe I made mistakes. If you found any fixes on my pull request, please tell me.

Thank you.
