### PR TITLE
Fix Callback#method_missing to handle under_score named event

### DIFF
--- a/lib/chatroid/callback.rb
+++ b/lib/chatroid/callback.rb
@@ -5,7 +5,7 @@ class Chatroid
     # * on_message      : store a given block as callback for "message"
     # * trigger_message : trigger callbacks for "message" with given args
     def method_missing(method_name, *args, &block)
-      if method_name =~ /(list|on|trigger)_([a-z0-9]+)/
+      if method_name =~ /(list|on|trigger)_([a-z0-9_]+)/
         send($1, $2, *args, &block)
       else
         super

--- a/spec/chatroid/callback_spec.rb
+++ b/spec/chatroid/callback_spec.rb
@@ -56,4 +56,14 @@ describe Chatroid::Callback do
       instance.trigger_xxx(args)
     end
   end
+
+  describe "#method_missing" do
+    it "should hundle under_score event like x_x" do
+      callback = proc {}
+      callback.should_receive(:call)
+      instance.on_x_x(&callback)
+      instance.send(:list, 'x_x').should_not be_empty
+      instance.trigger_x_x
+    end
+  end
 end


### PR DESCRIPTION
My previous pull request relating with #20 is not working well. So I made fix.

I feel sorry for pushing bad pull request. If you satisfied with this, please merge. Or refuse this pull request and revert previous pull request changes.

Thank you.
